### PR TITLE
To output the feature's topological information, revise FeatureFloodC…

### DIFF
--- a/modules/phase_field/include/postprocessors/FeatureFloodCount.h
+++ b/modules/phase_field/include/postprocessors/FeatureFloodCount.h
@@ -84,6 +84,14 @@ public:
   /// Returns the variable representing the passed in feature
   virtual unsigned int getFeatureVar(unsigned int feature_id) const;
 
+  /// Returns the feature ID representing the passed in feature (Grain ID)
+  virtual unsigned int getFeatureID(unsigned int feature_id) const;
+
+  virtual std::vector<unsigned int> getAdjacentID(unsigned int feature_id) const;
+
+  /// Returns the number of adjacent grains for grain ID
+  virtual unsigned int getNumAdjacentGrains(unsigned int feature_id) const;
+
   /// Returns the number of coupled varaibles
   std::size_t numCoupledVars() const { return _n_vars; }
 
@@ -164,9 +172,11 @@ public:
     FeatureData(std::size_t var_index,
                 Status status,
                 unsigned int id = invalid_id,
+                std::vector<unsigned int> adjacent_id = std::vector<unsigned int>(),
                 std::vector<BoundingBox> bboxes = {BoundingBox()})
       : _var_index(var_index),
         _id(id),
+        _adjacent_id(adjacent_id),
         _bboxes(bboxes), // Assume at least one bounding box
         _min_entity_id(DofObject::invalid_id),
         _vol_count(0),
@@ -287,6 +297,9 @@ public:
 
     /// An ID for this feature
     unsigned int _id;
+
+    /// The vecor of adjacent feature ID for this feature
+    std::vector<unsigned int> _adjacent_id;    
 
     /// The vector of bounding boxes completely enclosing this feature
     /// (multiple used with periodic constraints)

--- a/modules/phase_field/src/postprocessors/FeatureFloodCount.C
+++ b/modules/phase_field/src/postprocessors/FeatureFloodCount.C
@@ -41,6 +41,7 @@ dataStore(std::ostream & stream, FeatureFloodCount::FeatureData & feature, void 
   storeHelper(stream, feature._periodic_nodes, context);
   storeHelper(stream, feature._var_index, context);
   storeHelper(stream, feature._id, context);
+  storeHelper(stream, feature._adjacent_id, context);
   storeHelper(stream, feature._bboxes, context);
   storeHelper(stream, feature._orig_ids, context);
   storeHelper(stream, feature._min_entity_id, context);
@@ -72,6 +73,7 @@ dataLoad(std::istream & stream, FeatureFloodCount::FeatureData & feature, void *
   loadHelper(stream, feature._periodic_nodes, context);
   loadHelper(stream, feature._var_index, context);
   loadHelper(stream, feature._id, context);
+  loadHelper(stream, feature._adjacent_id, context);
   loadHelper(stream, feature._bboxes, context);
   loadHelper(stream, feature._orig_ids, context);
   loadHelper(stream, feature._min_entity_id, context);
@@ -836,6 +838,63 @@ FeatureFloodCount::getFeatureVar(unsigned int feature_id) const
                : invalid_id;
   }
 
+  return invalid_id;
+}
+
+unsigned int
+FeatureFloodCount::getFeatureID(unsigned int feature_id) const
+{   
+  if (feature_id >= _feature_id_to_local_index.size())
+    return invalid_id;
+
+  auto local_index = _feature_id_to_local_index[feature_id];
+  if (local_index != invalid_size_t)
+  {
+    mooseAssert(local_index < _feature_sets.size(), "local_index out of bounds");
+
+    return _feature_sets[local_index]._status != Status::INACTIVE
+               ? _feature_sets[local_index]._id
+               : invalid_id;
+  }
+
+  return invalid_id;
+}
+
+std::vector<unsigned int>
+FeatureFloodCount::getAdjacentID(unsigned int feature_id) const
+{ 
+  std::vector<unsigned int> invalid_id_vector(10,invalid_id);
+
+  if (feature_id >= _feature_id_to_local_index.size())
+    return invalid_id_vector;
+
+  auto local_index = _feature_id_to_local_index[feature_id];
+  if (local_index != invalid_size_t)
+  {
+    mooseAssert(local_index < _feature_sets.size(), "local_index out of bounds");
+
+    return _feature_sets[local_index]._status != Status::INACTIVE
+               ? _feature_sets[local_index]._adjacent_id
+               : invalid_id_vector;
+  }
+  return invalid_id_vector;
+}
+
+unsigned int
+FeatureFloodCount::getNumAdjacentGrains(unsigned int feature_id) const
+{   
+  if (feature_id >= _feature_id_to_local_index.size())
+    return invalid_id;
+
+  auto local_index = _feature_id_to_local_index[feature_id];
+  if (local_index != invalid_size_t)
+  {
+    mooseAssert(local_index < _feature_sets.size(), "local_index out of bounds");
+
+    return _feature_sets[local_index]._status != Status::INACTIVE
+               ? _feature_sets[local_index]._adjacent_id.size()
+               : invalid_id;
+  }
   return invalid_id;
 }
 
@@ -2267,3 +2326,4 @@ const std::size_t FeatureFloodCount::invalid_size_t = std::numeric_limits<std::s
 const unsigned int FeatureFloodCount::invalid_id = std::numeric_limits<unsigned int>::max();
 const processor_id_type FeatureFloodCount::invalid_proc_id =
     std::numeric_limits<processor_id_type>::max();
+    


### PR DESCRIPTION
## Reason
I have modified the `FeatureFloodCount` class to allow it to store the IDs of adjacent features and calculate the number of adjacent features. This enhancement is aimed at improving the functionality of the class.

## Design
In this enhancement, I have added the ability to record and access the IDs of adjacent features within the `FeatureFloodCount` class. I have introduced new functions, including `getAdjacentID`, which allows users to retrieve the IDs of adjacent features. This design change enhances the usability of the class by providing access to information about neighboring features.

## Impact
This enhancement does not change existing APIs but adds new functionality to the `FeatureFloodCount` class. Users can now retrieve information about adjacent features, which can be useful for various applications.

